### PR TITLE
Upgrade firebelley/godot-export to 2.7.0.

### DIFF
--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: create executables
-        uses: firebelley/godot-export@dev
+        uses: firebelley/godot-export@2.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
           GODOT_MONO_FILE_VERSION: 3.3-rc9


### PR DESCRIPTION
- Switch from unstable 'dev' version to new release 2.7.0, since it now
  contains the fix for firebelley/godot-export#51.