### PR TITLE
Fix state machine reset bug.

### DIFF
--- a/IStateMachine.cs
+++ b/IStateMachine.cs
@@ -2,6 +2,12 @@ using System;
 
 public interface IStateMachine <T> where T : Enum
 {
+  public enum ResetOption
+  {
+    IgnoreTransitionActions,
+    ExecuteTransitionActions
+  }
+
   public delegate void TransitionAction();
   public delegate bool TransitionTrigger();
   public bool Is (T state);
@@ -18,5 +24,5 @@ public interface IStateMachine <T> where T : Enum
   public void PopIf (bool condition);
   public void PopIf (T state);
   public void PopIf (T state, bool condition);
-  public void Reset();
+  public void Reset (ResetOption resetOption = ResetOption.IgnoreTransitionActions);
 }

--- a/Player.cs
+++ b/Player.cs
@@ -144,7 +144,7 @@ public class Player : KinematicBody2D
 
   private void Respawn()
   {
-    _stateMachine.Reset();
+    _stateMachine.Reset (IStateMachine <State>.ResetOption.ExecuteTransitionActions);
     GlobalPosition = new Vector2 (952, -4032);
     EnableFloors();
   }

--- a/StateMachine.cs
+++ b/StateMachine.cs
@@ -100,20 +100,7 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
       case 0:
         break;
       case 1:
-        var to = triggeredStates.Single();
-
-        if (CanPopTo (to))
-        {
-          Pop();
-        }
-        else if (IsReversible (to))
-        {
-          Push (to);
-        }
-        else
-        {
-          To (to);
-        }
+        TriggerState (triggeredStates.Single());
 
         break;
       default:
@@ -180,11 +167,13 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
     ExecuteChangeState (to);
   }
 
-  public void Reset()
+  public void Reset (IStateMachine <T>.ResetOption resetOption)
   {
+    if (resetOption == IStateMachine <T>.ResetOption.ExecuteTransitionActions) TriggerState (_initialState);
     _currentState = _initialState;
     _parentState = _initialState;
     _childStates.Clear();
+    Log.Info ("Reset state machine.");
   }
 
   public void PopIf (bool condition)
@@ -213,6 +202,22 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
     }
 
     return _childStates.Count > 1 ? _childStates.Skip (1).First() : _parentState;
+  }
+
+  private void TriggerState (T to)
+  {
+    if (CanPopTo (to))
+    {
+      Pop();
+    }
+    else if (IsReversible (to))
+    {
+      Push (to);
+    }
+    else
+    {
+      To (to);
+    }
   }
 
   private bool ShouldExecuteChangeState (T to)


### PR DESCRIPTION
Problem:

- State machine ignores transition actions when reset, leading to
  incorrect state side-effects, such as leaving the cliff-arresting
  sound playing when respawning during a cliff arrest.

Solution:

- Provide the option when resetting the state machine to specify that
  transition actions should be executed. The default is to not execute
  them, since it adds side-effects to the reset, which would be
  unexpected. However, not executing can also leave unwanted
  side-effects, which is why the option is provided. Making it explicit
  as an enum makes the code easy to read and understand.

- Specify that transition actions should be executed when resetting the
  player state machine during a respawn, so that sounds such as the
  cliff arrest are not left playing that should not be due to bypassing
  transition actions that would have stopped them.
