### PR TITLE
Fix CI double release issue.

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -1,0 +1,41 @@
+name: build
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  LANG: "en_US.UTF-8"
+
+jobs:
+  export:
+    name: export executables
+    runs-on: ubuntu-latest
+    steps:
+      - name: set locale
+        run: |
+          sudo locale-gen en_US.UTF-8
+          sudo update-locale LANG=en_US.UTF-8
+      - name: checkout code
+        uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - name: create executables
+        uses: firebelley/godot-export@v2.8.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
+          GODOT_MONO_FILE_VERSION: 3.3.2-stable
+          GODOT_MONO_URL_VERSION: 3.3.2
+        with:
+          godot_executable_download_url: https://downloads.tuxfamily.org/godotengine/${{env.GODOT_MONO_URL_VERSION}}/mono/Godot_v${{env.GODOT_MONO_FILE_VERSION}}_mono_linux_headless_64.zip
+          godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/${{env.GODOT_MONO_URL_VERSION}}/mono/Godot_v${{env.GODOT_MONO_FILE_VERSION}}_mono_export_templates.tpz
+          relative_project_path: ./
+          archive_export_output: true
+          create_release: false
+          base_version: 0.0.1
+      - name: upload executables
+        uses: actions/upload-artifact@v2
+        with:
+          name: executables
+          path: ~/.local/share/godot/dist/*.zip

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - develop
 
 env:
   LANG: "en_US.UTF-8"
@@ -33,7 +32,7 @@ jobs:
           godot_export_templates_download_url: https://downloads.tuxfamily.org/godotengine/${{env.GODOT_MONO_URL_VERSION}}/mono/Godot_v${{env.GODOT_MONO_FILE_VERSION}}_mono_export_templates.tpz
           relative_project_path: ./
           archive_export_output: true
-          create_release: false
+          create_release: true
           base_version: 0.0.1
       - name: upload executables
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Problem:

- Pushing a release to develop will re-release when merged back into
  master.

Solution:

- Only release on pushes to master.
- Every push to master is a release.

Reverts 468f6880b53ad1caeae4250d12662e84b534a45f because it only
addresses deployments but not releases. This commit fixes both
simultaneously.
