### PR TITLE
Delete GitHub release assets.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,3 +64,13 @@ jobs:
           ITCH_USER: forerunnergames
           PACKAGE: coa-linux.zip
           VERSION: ${{ steps.download_linux.outputs.version }}
+
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete GitHub executables
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GH_ACTIONS_TOKEN }}
+        tag: tags/${{ github.event.release.tag_name }}
+        assets: 'coa-*.zip'


### PR DESCRIPTION
Problem:

- After deployment to itch.io, it is not desirable for an extra copy of
  the released executables to be available for download on the GitHub
  release. It is convenient, however, to leave the zipped source code
  release asset there.

Solution:

- Use mknejp/delete-release-assets to delete the released GitHub
  executables post itch.io deployment, leaving only the zipped source
  code release assets for download.
