### PR TITLE
Fix waterfall sound bug.

### DIFF
--- a/scripts/Cliffs.cs
+++ b/scripts/Cliffs.cs
@@ -150,6 +150,7 @@ public class Cliffs : Area2D
       {
         if (node2 is not AudioStreamPlayer2D sound) continue;
 
+        LoopAudio (sound.Stream);
         sound.Playing = !isWinter;
       }
     }


### PR DESCRIPTION
Problem:

  - Waterfall sounds stops playing after the music loops.

Solution

  - Set waterfall sounds to loop, both in the Godot editor &
    programmatically when changing / initializing seasons.
