### PR TITLE
Fix README build badges statuses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Release:
 
-[![master](https://github.com/forerunnergames/coa/workflows/build/badge.svg)](https://github.com/forerunnergames/coa/actions/workflows/release.yml)
+[![master](https://github.com/forerunnergames/coa/workflows/release/badge.svg)](https://github.com/forerunnergames/coa/actions/workflows/release.yml)
 
 Development:
 


### PR DESCRIPTION
- Make the release build point to the release build, not the development
  build.
