### PR TITLE
Fix GitHub Actions release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: create executables
-        uses: firebelley/godot-export@v2.8.0
+        uses: firebelley/godot-export@v2.8.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
           GODOT_MONO_FILE_VERSION: 3.3.3-stable


### PR DESCRIPTION
- Update GitHub Action firebelley/godot-export 2.8.0 => 2.8.1
