### PR TITLE
Fix GitHub Action deployment cleanup.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: 3. deploy
 
 on:
   release:
-    types: [created, edited]
+    types: [published]
 
 jobs:
   deploy_mac:
@@ -67,11 +67,12 @@ jobs:
 
   cleanup:
     name: cleanup
+    needs: [deploy_mac, deploy_windows, deploy_linux]
     runs-on: ubuntu-latest
     steps:
       - name: delete github executables
         uses: mknejp/delete-release-assets@v1
         with:
           token: ${{ secrets.GH_ACTIONS_TOKEN }}
-          tag: tags/${{ github.event.release.tag_name }}
+          tag: ${{ github.event.release.tag_name }}
           assets: 'coa-*.zip'


### PR DESCRIPTION
- Cleanup should delete newly released executables from GitHub, so they
  will only be available on itch.io after deployment. Remove the "tags/"
  prefix from the tag specification that is causing the GitHub Action to
  not find the currently released tag.

- Run cleanup only after itch.io deployment is complete, as it depends
  on the GitHub executables being present.

- Only deploy to itch.io when a release is 'published', not 'created' or
  'edited'. This is the recommended standard practice to prevent
  unintended, faulty or duplicate deployments (such as from draft
  releases).
