### PR TITLE
Remove broken deployment cleanup step.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,14 +65,3 @@ jobs:
           PACKAGE: coa-linux.zip
           VERSION: ${{ steps.download_linux.outputs.version }}
 
-  cleanup:
-    name: cleanup
-    needs: [deploy_mac, deploy_windows, deploy_linux]
-    runs-on: ubuntu-latest
-    steps:
-      - name: delete github executables
-        uses: mknejp/delete-release-assets@v1
-        with:
-          token: ${{ secrets.GH_ACTIONS_TOKEN }}
-          tag: ${{ github.event.release.tag_name }}
-          assets: 'coa-*.zip'


### PR DESCRIPTION
The cleanup step in the GitHub Action deployment should remove all
coa*.zip zipped executables from the GitHub release automatically so
they will only be available on Itch.io. The plugin is not working
because it says it can't find any assets to remove, so remove it for now
and as a workaround manually remove the assets from the GitHub release
using the web interface.
