### PR TITLE
Ignore root-level *.import files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tests/.mono/
 tests/logs/
 tests/metadata/
 tests/results/
+/*.import


### PR DESCRIPTION
- These auto-generated .import files are unavoidable with Godot, but
  only ignore the root-level files because the useful ones will always
  be located under assets/. Assets such as image files in the root
  directory are not game-related, and should never be imported into
  Godot.
