### PR TITLE
Improve logging & debug text printing.

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -4799,7 +4799,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 FlightPathColor = Color( 1, 0, 0, 1 )
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 1"]
 visible = false
@@ -4839,7 +4839,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 FlightPathColor = Color( 0, 1, 0, 1 )
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 2"]
 visible = false
@@ -4879,7 +4879,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 FlightPathColor = Color( 0, 0, 1, 1 )
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 3"]
 visible = false
@@ -4919,7 +4919,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 FlightPathColor = Color( 1, 0.701961, 0, 1 )
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 4"]
 visible = false
@@ -4959,7 +4959,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 FlightPathColor = Color( 1, 0.376471, 0, 1 )
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 5"]
 visible = false
@@ -5000,7 +5000,7 @@ __meta__ = {
 }
 FlightPathColor = Color( 0, 0.952941, 1, 1 )
 NearestPerchFrequency = 1.0
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 6"]
 visible = false
@@ -5041,7 +5041,7 @@ __meta__ = {
 }
 FlightPathColor = Color( 0.0117647, 0.196078, 0.0862745, 1 )
 NearestPerchFrequency = 1.0
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 7"]
 visible = false
@@ -5082,7 +5082,7 @@ __meta__ = {
 }
 FlightPathColor = Color( 0, 0.670588, 1, 1 )
 NearestPerchFrequency = 1.0
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 8"]
 visible = false
@@ -5123,7 +5123,7 @@ __meta__ = {
 }
 FlightPathColor = Color( 0.415686, 0.32549, 0.117647, 1 )
 NearestPerchFrequency = 1.0
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 9"]
 visible = false
@@ -5164,7 +5164,7 @@ __meta__ = {
 }
 FlightPathColor = Color( 1, 0.588235, 0.384314, 1 )
 NearestPerchFrequency = 1.0
-LogLevel = 2
+LogLevel = 0
 
 [node name="PerchingCollider" type="Area2D" parent="Butterfly 10"]
 visible = false

--- a/scripts/Butterfly.cs
+++ b/scripts/Butterfly.cs
@@ -171,7 +171,7 @@ public class Butterfly : AnimatedSprite
     _drawRect = delegate (Rect2 rect, Color color, bool filled) { DrawRect (rect, color, filled); };
     _idleTimer = GetNode <Timer> ("IdleTimer");
     _lastPosition = Position;
-    _stateMachine = new StateMachine <State> (TransitionTable, State.Flying, Name);
+    _stateMachine = new StateMachine <State> (TransitionTable, State.Flying, Name) { LogLevel = LogLevel };
     _stateMachine.OnTransitionTo (State.Perching, () => Animation = PerchingAnimation);
     _stateMachine.OnTransitionTo (State.Evading, () => Animation = EvadingAnimation);
     _stateMachine.OnTransitionTo (State.Flying, () => Animation = FlyingAnimation);

--- a/scripts/Cliffs.cs
+++ b/scripts/Cliffs.cs
@@ -8,6 +8,7 @@ public class Cliffs : Area2D
 {
   [Export] public Season InitialSeason = Season.Summer;
   [Export] public Color InitialClearColor = Color.Color8 (11, 118, 255);
+  [Export] public Log.Level LogLevel = Log.Level.Info;
 
   // Field must be publicly accessible from Player.cs
   public Season CurrentSeason;
@@ -50,7 +51,7 @@ public class Cliffs : Area2D
   public override void _Ready()
   {
     // ReSharper disable once ExplicitCallerInfoArgument
-    _log = new Log (Name);
+    _log = new Log (Name) { CurrentLevel = LogLevel };
     _clearColor = InitialClearColor;
     VisualServer.SetDefaultClearColor (_clearColor);
     _waterfallZIndex.Add (Season.Summer, 33);

--- a/scripts/Log.cs
+++ b/scripts/Log.cs
@@ -17,7 +17,7 @@ public class Log
     All
   }
 
-  public Log ([CallerFilePath] string name = "") { _name = Path.GetFileNameWithoutExtension (name); }
+  public Log ([CallerFilePath] string name = "") => _name = Path.GetFileNameWithoutExtension (name);
   public bool All (string message) => CurrentLevel > Level.Debug && Print (message, Level.All);
   public bool Debug (string message) => CurrentLevel > Level.Info && Print (message, Level.Debug);
   public bool Info (string message) => CurrentLevel > Level.Warn && Print (message, Level.Info);

--- a/scripts/StateMachine.cs
+++ b/scripts/StateMachine.cs
@@ -26,6 +26,7 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
   private readonly List <T> _triggeredToStates = new();
   private readonly List <T> _fromStates = new();
   private readonly List <T> _toStates = new();
+  private bool _isFirstUpdate = true;
   private readonly Log _log;
 
   // ReSharper disable once ExplicitCallerInfoArgument
@@ -71,7 +72,6 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
     _currentState = initialState;
     _parentState = initialState;
     _transitionTable = transitionTable;
-    _log.Info ($"Initial state: {ToString (_initialState)}");
   }
 
   public T GetState() => _currentState;
@@ -123,6 +123,12 @@ public class StateMachine <T> : IStateMachine <T> where T : struct, Enum
 
   public void Update()
   {
+    if (_isFirstUpdate)
+    {
+      _log.Info ($"Initial state: {ToString (_initialState)}");
+      _isFirstUpdate = false;
+    }
+
     if (!_triggers.ContainsKey (_currentState) && !_triggers.ContainsKey (AnyState)) return;
 
     _fromStates.Clear();

--- a/scripts/Weapon.cs
+++ b/scripts/Weapon.cs
@@ -31,13 +31,13 @@ public class Weapon
 
   // @formatter:on
 
-  public Weapon (Node player)
+  public Weapon (Node player, Log.Level logLevel)
   {
     _playerAnimator1 = player.GetNode <AnimationPlayer> ("Sprites/AnimationPlayer1");
     _playerAnimator2 = player.GetNode <AnimationPlayer> ("Sprites/AnimationPlayer2");
     _backpackSprite = player.GetNode <Sprite> ("Sprites/backpack");
     _itemInBackpackSprite = player.GetNode <Sprite> ("Sprites/item-in-backpack");
-    InitializeStateMachine();
+    InitializeStateMachine (logLevel);
   }
 
   // ReSharper disable once MemberCanBeMadeStatic.Global
@@ -118,9 +118,9 @@ public class Weapon
     }
   }
 
-  private void InitializeStateMachine()
+  private void InitializeStateMachine (Log.Level logLevel)
   {
-    _sm = new StateMachine <State> (TransitionTable, State.Unequipped);
+    _sm = new StateMachine <State> (TransitionTable, State.Unequipped) { LogLevel = logLevel };
     _sm.OnTransition (State.Unequipped, State.Equipped, StartEquipping);
     _sm.OnTransition (State.Equipped, State.Unequipped, StartUnequipping);
     _sm.AddTrigger (State.Unequipped, State.Equipped, ShouldEquip);


### PR DESCRIPTION
- Export all top-level log levels to the Godot editor for easy debugging
  from the editor UI.

- Inject all top-level log levels recursively down into every dependent
  component having its own log, so that log levels are homogeneous.

- Allow printing of static messages for in-game debugging text in
  Player.cs, that is enabled / disabled via the T key on the keyboard.
  This allows for a message that is not being updated every frame to not
  disappear after a single frame and actually persist on the screen
  until some future state decides to change it. Static messages can also
  be removed. (Printing of dynamic / per-frame-updated messages are
  already supported & in use).
