### PR TITLE
Remove unused Player.cs code.

### DIFF
--- a/scripts/Player.cs
+++ b/scripts/Player.cs
@@ -1304,7 +1304,6 @@ public class Player : KinematicBody2D
     _stateMachine.OnTransitionFrom (State.Idle, () =>
     {
       if (IsInGroup ("Perchable Parent")) RemoveFromGroup ("Perchable Parent");
-      // if (_sprite.IsInGroup ("Perchable")) _sprite.RemoveFromGroup ("Perchable");
       _cameraSmoothingTimer.Stop();
     });
 
@@ -1323,14 +1322,12 @@ public class Player : KinematicBody2D
     _stateMachine.OnTransitionTo (State.Idle, () =>
     {
       if (!IsInGroup ("Perchable Parent")) AddToGroup ("Perchable Parent");
-      // if (!_sprite.IsInGroup ("Perchable")) _sprite.AddToGroup ("Perchable");
       _wasRunning = false;
     });
 
     _stateMachine.OnTransitionFrom (State.CliffHanging, () =>
     {
       if (IsInGroup ("Perchable Parent")) RemoveFromGroup ("Perchable Parent");
-      // if (_sprite.IsInGroup ("Perchable")) _sprite.RemoveFromGroup ("Perchable");
     });
 
     _stateMachine.OnTransitionTo (State.CliffHanging, () =>
@@ -1338,7 +1335,6 @@ public class Player : KinematicBody2D
       _animationPlayer.Play (CliffHangingAnimation);
       _weapon.Unequip();
       if (!IsInGroup ("Perchable Parent")) AddToGroup ("Perchable Parent");
-      // if (!_sprite.IsInGroup ("Perchable")) _sprite.AddToGroup ("Perchable");
     });
 
     _stateMachine.OnTransitionTo (State.Walking, () =>


### PR DESCRIPTION
- Remove some obsolete, commented-out code from the old sprite animation
  system that was being used to allow butterflies to perch on the
  player. This feature has been temporarily removed since implementing
  the new animation system broke it, but will return eventually. This
  was supposed to be part of #55.
