### PR TITLE
Fix player weapon equipping bug.

### DIFF
--- a/scripts/Weapon.cs
+++ b/scripts/Weapon.cs
@@ -31,12 +31,12 @@ public class Weapon
 
   // @formatter:on
 
-  public Weapon (Node player, Log.Level logLevel)
+  public Weapon (Node sprites, Log.Level logLevel)
   {
-    _playerAnimator1 = player.GetNode <AnimationPlayer> ("Sprites/AnimationPlayer1");
-    _playerAnimator2 = player.GetNode <AnimationPlayer> ("Sprites/AnimationPlayer2");
-    _backpackSprite = player.GetNode <Sprite> ("Sprites/backpack");
-    _itemInBackpackSprite = player.GetNode <Sprite> ("Sprites/item-in-backpack");
+    _playerAnimator1 = sprites.GetNode <AnimationPlayer> ("AnimationPlayer1");
+    _playerAnimator2 = sprites.GetNode <AnimationPlayer> ("AnimationPlayer2");
+    _backpackSprite = sprites.GetNode <Sprite> ("backpack");
+    _itemInBackpackSprite = sprites.GetNode <Sprite> ("item-in-backpack");
     InitializeStateMachine (logLevel);
   }
 


### PR DESCRIPTION
Problem:

  - Pressing the E key on the keyboard to equip the player's weapon
    crashes the game. This is a regression caused by #61 that
    inadvertently passed the "Sprites" node into the Weapon.cs
    constructor instead of the "Player" node that was expected.

  - Modify the Weapon.cs constructor to use the "Sprites" node instead
    of the entire "Player" node, which simplifies the code and utilizes
    the Principle of Least Privilege.
