### PR TITLE
Fix nonexistent cell log warning message bug.

### DIFF
--- a/scripts/Tools.cs
+++ b/scripts/Tools.cs
@@ -313,12 +313,7 @@ public static class Tools
   {
     var cellId = t.GetCell ((int)cell.x, (int)cell.y);
 
-    if (cellId == -1)
-    {
-      _log.Warn ($"Cell {cell} doesn't exist in TileMap: \"{t.Name}\"");
-
-      return Vector2.Zero;
-    }
+    if (cellId == -1) return Vector2.Zero;
 
     return t.TileSet.TileGetRegion (cellId).Size * t.Scale;
   }


### PR DESCRIPTION
Problem:

- There is a log message in Tools#GetTileCellGlobalSize that warns if
  the cell doesn't exist in the tilemap. The same message is being
  spammed repeatedly when another Tools method can't find a tilemap cell
  and returns a default cell (0, 0), which gets passed into this method,
  and so will never be found in the tilemap.

Solution:

- Remove the aforementioned log message in Tools#GetTileCellGlobalSize.
  This is expected behavior as these methods have been designed to
  handle the "not found" cases with default values. The warning
  therefore, is misleading and unnecessary.
