### PR TITLE
Minor cleanups.

### DIFF
--- a/scripts/Butterfly.cs
+++ b/scripts/Butterfly.cs
@@ -439,9 +439,9 @@ public class Butterfly : AnimatedSprite
     _perchesUnvisited.Clear();
 
     GetTree().GetNodesInGroup (PerchableGroupName).Cast <Node2D>().ToList().ForEach (node =>
-      _perches.AddRange (PerchablesFactory.Create (node, _perchableDrawPrefs, PositionEpsilon)));
+      _perches.AddRange (PerchableFactory.Create (node, _perchableDrawPrefs, PositionEpsilon)));
 
-    var perch = PerchablesFactory.CreateDefault (this, _perchableDrawPrefs, PositionEpsilon);
+    var perch = PerchableFactory.CreateDefault (this, _perchableDrawPrefs, PositionEpsilon);
     perch.Disabled = true;
     _perches.Add (perch);
     ReplenishUnvisitedPerches();

--- a/scripts/PerchableFactory.cs
+++ b/scripts/PerchableFactory.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using Godot;
 using static Tools;
 
-public static class PerchablesFactory
+public static class PerchableFactory
 {
   private static readonly Vector2 LocalScale = new(8, 8);
 

--- a/scripts/Weapon.cs
+++ b/scripts/Weapon.cs
@@ -54,21 +54,19 @@ public class Weapon
   public void OnUnequipAnimationStarted() => _isUnequipping = true;
   public void OnUnequipAnimationFinished() => _isUnequipping = false;
 
-  private bool ShouldEquip()
-  {
-    // @formatter:off
-    return WasItemKeyPressedOnce() && _backpackSprite.Visible && _itemInBackpackSprite.Visible && !_isUnequipping &&
-           _playerAnimator1.AssignedAnimation != "player_cliff_arresting" &&
-           _playerAnimator1.AssignedAnimation != "player_cliff_hanging" &&
-           _playerAnimator1.AssignedAnimation != "player_climbing_up" &&
-           _playerAnimator1.AssignedAnimation != "player_free_falling";
-    // @formatter:on
-  }
+  // @formatter:off
 
-  private bool ShouldUnequip()
-  {
-    return WasItemKeyPressedOnce() && _backpackSprite.Visible && !_itemInBackpackSprite.Visible && !_isEquipping;
-  }
+  private bool ShouldEquip() =>
+    WasItemKeyPressedOnce() && _backpackSprite.Visible && _itemInBackpackSprite.Visible && !_isUnequipping &&
+    _playerAnimator1.AssignedAnimation != "player_cliff_arresting" &&
+    _playerAnimator1.AssignedAnimation != "player_cliff_hanging" &&
+    _playerAnimator1.AssignedAnimation != "player_climbing_up" &&
+    _playerAnimator1.AssignedAnimation != "player_free_falling";
+
+  // @formatter:on
+
+  private bool ShouldUnequip() =>
+    WasItemKeyPressedOnce() && _backpackSprite.Visible && !_itemInBackpackSprite.Visible && !_isEquipping;
 
   private void StartEquipping()
   {


### PR DESCRIPTION
Tools.cs:

  - Make methods expression bodies where possible.
  - Make log property read only.
  - Make log property use target-typed new.
  - Capitalize log property since it's now read only.
  - Rearrange methods to group one-liners together, put public before
    private, shorter methods before longer ones.
  - Shorten some one-liner parameter names to improve readability.

PerchablesFactory.cs

  - Rename class to PerchableFactory, to be consistent with project
    naming standards; e.g., DropdownableFactory.

Weapon.cs:

  - Make methods expression bodies where possible.
