### PR TITLE
Fix frozen waterfall dropdown bug.

### DIFF
--- a/scripts/TileMapDropdownable.cs
+++ b/scripts/TileMapDropdownable.cs
@@ -34,7 +34,7 @@ public class TileMapDropdownable : AbstractDropdownable
     if (tileName.Empty()) return;
 
     _IsDropping = true;
-    Log.Info ($"Dropping down through [{tileName}].");
+    Log.Info ($"Dropping down through tile [{tileName}].");
     _droppingThroughTileMap.SetCollisionMaskBit (0, false);
     _droppingNode.SetCollisionMaskBit (1, false);
     for (var i = 0; i < TileNamesToDropdownFrames[tileName]; ++i) await _droppingNode.ToSignal (_droppingNode.GetTree(), "idle_frame");


### PR DESCRIPTION
Problem:

  - Player can't drop down through frozen waterfall ground. This is
    caused by a known bug in Godot that doesn't allow RayCast2D to add
    collision exceptions for TileMaps. Because of this bug, the player's
    feet raycasts can't detect both the normal cliff ground and the
    frozen waterfall ground at the same time because they are at the
    exact same height, but both must be disabled to allow dropping down
    through the frozen waterfall ground.

Solution:

  - Add workaround in Dropdown.cs to allow RayCast2D to ignore TileMap
    collisions in order to disable both the cliff ground and the frozen
    waterfall ground that are at the same exact height. This was
    supposed to be fixed by #66 "Fix multi-ground dropdown bug", but it
    only addressed multiple non-overlapping ground colliders being
    side-by-side at the same height, where the player's feet raycasts
    were colliding with multiple, horizontally-parallel ground
    colliders. This completes the fix for #66 by addressing the player's
    feet raycasts colliding with multiple ground colliders overlapping
    each other at the same height.

  - The workaround involves looping RayCast2D collisions multiple
    times per frame to get all of them instead of just the first one it
    hits:

      1. In the loop, check if the collision object is a TileMap & if so
         add it manually to a custom list of TileMap exceptions.

      2. Each iteration check if the collision object is both a TileMap
         & in the exception list & if so ignore it.

      3. Force the raycast to update in the same frame using
         RayCast2D#ForceRaycastUpdate

      4. Clear the TileMap exception list outside of & before the loop.

Miscellaneous:

  - Improve clarity of logging message in TileMapDropdownable.cs to help
    with debugging.

See https://github.com/godotengine/godot/issues/17090 "Collision
exceptions don't work with TileMap node" for more information.
