### PR TITLE
Fix waterfall bugs & refactor.

### DIFF
--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=173 format=2]
+[gd_scene load_steps=174 format=2]
 
 [ext_resource path="res://scripts/Player.cs" type="Script" id=1]
 [ext_resource path="res://assets/textures/klas-layers/hand-left.png" type="Texture" id=2]
@@ -18,6 +18,7 @@
 [ext_resource path="res://assets/textures/sign-font.png" type="Texture" id=16]
 [ext_resource path="res://assets/textures/sign-arrow-left-blank.png" type="Texture" id=17]
 [ext_resource path="res://scenes/ui.tscn" type="PackedScene" id=18]
+[ext_resource path="res://scripts/Waterfall.cs" type="Script" id=19]
 [ext_resource path="res://assets/textures/klas-layers/hat-outline.png" type="Texture" id=20]
 [ext_resource path="res://assets/textures/klas-layers/boot-right.png" type="Texture" id=21]
 [ext_resource path="res://assets/textures/klas-layers/shirt.png" type="Texture" id=22]
@@ -4182,34 +4183,6 @@ animations = [ {
 "speed": 10.0
 } ]
 
-[sub_resource type="AtlasTexture" id=185]
-atlas = ExtResource( 38 )
-region = Rect2( 0, 400, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=186]
-atlas = ExtResource( 38 )
-region = Rect2( 112, 400, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=187]
-atlas = ExtResource( 38 )
-region = Rect2( 224, 400, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=188]
-atlas = ExtResource( 38 )
-region = Rect2( 336, 400, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=189]
-atlas = ExtResource( 38 )
-region = Rect2( 448, 400, 112, 80 )
-
-[sub_resource type="SpriteFrames" id=179]
-animations = [ {
-"frames": [ SubResource( 185 ), SubResource( 186 ), SubResource( 187 ), SubResource( 188 ), SubResource( 189 ) ],
-"loop": true,
-"name": "default",
-"speed": 10.0
-} ]
-
 [sub_resource type="AtlasTexture" id=190]
 atlas = ExtResource( 38 )
 region = Rect2( 0, 0, 112, 80 )
@@ -4220,34 +4193,6 @@ animations = [ {
 "loop": true,
 "name": "default",
 "speed": 5.0
-} ]
-
-[sub_resource type="AtlasTexture" id=191]
-atlas = ExtResource( 38 )
-region = Rect2( 0, 240, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=192]
-atlas = ExtResource( 38 )
-region = Rect2( 112, 240, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=193]
-atlas = ExtResource( 38 )
-region = Rect2( 224, 240, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=194]
-atlas = ExtResource( 38 )
-region = Rect2( 336, 240, 112, 80 )
-
-[sub_resource type="AtlasTexture" id=195]
-atlas = ExtResource( 38 )
-region = Rect2( 448, 240, 112, 80 )
-
-[sub_resource type="SpriteFrames" id=171]
-animations = [ {
-"frames": [ SubResource( 191 ), SubResource( 192 ), SubResource( 193 ), SubResource( 194 ), SubResource( 195 ) ],
-"loop": true,
-"name": "default",
-"speed": 10.0
 } ]
 
 [sub_resource type="AtlasTexture" id=196]
@@ -4276,6 +4221,62 @@ animations = [ {
 "loop": true,
 "name": "default",
 "speed": 5.0
+} ]
+
+[sub_resource type="AtlasTexture" id=185]
+atlas = ExtResource( 38 )
+region = Rect2( 0, 400, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=186]
+atlas = ExtResource( 38 )
+region = Rect2( 112, 400, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=187]
+atlas = ExtResource( 38 )
+region = Rect2( 224, 400, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=188]
+atlas = ExtResource( 38 )
+region = Rect2( 336, 400, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=189]
+atlas = ExtResource( 38 )
+region = Rect2( 448, 400, 112, 80 )
+
+[sub_resource type="SpriteFrames" id=179]
+animations = [ {
+"frames": [ SubResource( 185 ), SubResource( 186 ), SubResource( 187 ), SubResource( 188 ), SubResource( 189 ) ],
+"loop": true,
+"name": "default",
+"speed": 10.0
+} ]
+
+[sub_resource type="AtlasTexture" id=191]
+atlas = ExtResource( 38 )
+region = Rect2( 0, 240, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=192]
+atlas = ExtResource( 38 )
+region = Rect2( 112, 240, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=193]
+atlas = ExtResource( 38 )
+region = Rect2( 224, 240, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=194]
+atlas = ExtResource( 38 )
+region = Rect2( 336, 240, 112, 80 )
+
+[sub_resource type="AtlasTexture" id=195]
+atlas = ExtResource( 38 )
+region = Rect2( 448, 240, 112, 80 )
+
+[sub_resource type="SpriteFrames" id=171]
+animations = [ {
+"frames": [ SubResource( 191 ), SubResource( 192 ), SubResource( 193 ), SubResource( 194 ), SubResource( 195 ) ],
+"loop": true,
+"name": "default",
+"speed": 10.0
 } ]
 
 [sub_resource type="AtlasTexture" id=205]
@@ -4382,10 +4383,10 @@ extents = Vector2( 96, 64.0054 )
 extents = Vector2( 96, 64 )
 
 [sub_resource type="RectangleShape2D" id=118]
-extents = Vector2( 1016, 16 )
+extents = Vector2( 1016, 28 )
 
 [sub_resource type="RectangleShape2D" id=119]
-extents = Vector2( 1016, 16 )
+extents = Vector2( 1016, 28 )
 
 [sub_resource type="RectangleShape2D" id=120]
 extents = Vector2( 68, 4 )
@@ -5024,7 +5025,6 @@ __meta__ = {
 }
 
 [node name="Snow" type="TileMap" parent="Cliffs" groups=["Cliffs", "Winter"]]
-visible = false
 scale = Vector2( 8, 8 )
 z_index = 1
 tile_set = ExtResource( 3 )
@@ -5039,7 +5039,6 @@ __meta__ = {
 }
 
 [node name="Ice" type="TileMap" parent="Cliffs" groups=["Cliffs", "Ice", "Winter"]]
-visible = false
 scale = Vector2( 8, 8 )
 tile_set = ExtResource( 3 )
 cell_size = Vector2( 16, 16 )
@@ -5741,31 +5740,33 @@ tile_data = PoolIntArray( -544075464, 2, 0, -544075456, 11, 0, -544075448, 8, 0,
 position = Vector2( -40, 0 )
 texture = ExtResource( 13 )
 
-[node name="Waterfall - Upper" type="Area2D" parent="Cliffs"]
+[node name="Waterfall - Upper" type="Area2D" parent="Cliffs" groups=["Parent", "Waterfall"]]
 position = Vector2( 1532, -3544 )
 z_index = 32
 collision_layer = 34
 collision_mask = 5
+script = ExtResource( 19 )
 __meta__ = {
 "_edit_group_": true,
 "_edit_lock_": true
 }
 
-[node name="Frozen Ground" type="StaticBody2D" parent="Cliffs/Waterfall - Upper" groups=["Dropdownable", "Ground", "Winter"]]
+[node name="Frozen Ground" type="StaticBody2D" parent="Cliffs/Waterfall - Upper" groups=["Dropdownable", "Ground", "Waterfall", "Winter"]]
 visible = false
 position = Vector2( 0, -228 )
 collision_layer = 2
 collision_mask = 29
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Upper/Frozen Ground" groups=["Dropdownable", "Ground", "Winter"]]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Upper/Frozen Ground" groups=["Dropdownable", "Ground", "Waterfall", "Winter"]]
 shape = SubResource( 201 )
+one_way_collision = true
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Upper"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 visible = false
 position = Vector2( 0, 1716 )
 shape = SubResource( 202 )
 
-[node name="Water 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, -24 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5773,7 +5774,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 1"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 1" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 20.437
@@ -5781,7 +5782,7 @@ pitch_scale = 0.6
 max_distance = 100.0
 attenuation = 8.28211
 
-[node name="Water 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 360 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5789,14 +5790,14 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 2"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 2" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -16.0
 pitch_scale = 0.6
 attenuation = 8.28211
 
-[node name="Water 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 744 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5804,7 +5805,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 3"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 3" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -11.0
@@ -5812,7 +5813,7 @@ pitch_scale = 0.6
 max_distance = 3000.0
 attenuation = 8.28211
 
-[node name="Water 4" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 4" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 1128 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5820,7 +5821,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 4"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 4" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -6.0
@@ -5828,7 +5829,7 @@ pitch_scale = 0.6
 max_distance = 4000.0
 attenuation = 8.28211
 
-[node name="Water 5" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 5" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 1512 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5836,7 +5837,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 5"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 5" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -1.0
@@ -5844,7 +5845,7 @@ pitch_scale = 0.6
 max_distance = 5000.0
 attenuation = 8.28211
 
-[node name="Water 6" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 6" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 1896 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5852,7 +5853,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 6"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 6" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 4.0
@@ -5860,7 +5861,7 @@ pitch_scale = 0.6
 max_distance = 6000.0
 attenuation = 8.28211
 
-[node name="Water 7" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 7" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 2280 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5868,7 +5869,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 7"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 7" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 9.0
@@ -5876,7 +5877,7 @@ pitch_scale = 0.6
 max_distance = 7000.0
 attenuation = 8.28211
 
-[node name="Water 8" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 8" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 2664 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5884,7 +5885,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 8"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 8" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 14.0
@@ -5892,7 +5893,7 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Water 9" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 9" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 3048 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
@@ -5900,7 +5901,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 9"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 9" groups=["Attenuateable", "Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 19.0
@@ -5908,7 +5909,7 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Water 10" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Water 10" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 3408 )
 scale = Vector2( 8, 7 )
 frames = SubResource( 64 )
@@ -5916,7 +5917,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 10"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Upper/Water 10" groups=["Attenuateable", "Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 24.0
@@ -5924,76 +5925,77 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Mist - Top" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
-position = Vector2( -4, -24 )
-scale = Vector2( 8, 8 )
-frames = SubResource( 179 )
-
-[node name="Pool" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Pool" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 3384 )
 scale = Vector2( 8, 8 )
 z_index = -32
 frames = SubResource( 173 )
 
-[node name="Mist - Bottom" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
-position = Vector2( 4, 3376 )
-scale = Vector2( 8, 8 )
-frames = SubResource( 171 )
-
-[node name="Waves" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Waves" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
 position = Vector2( -4, 3384 )
 scale = Vector2( 8, 8 )
 z_index = -32
 frames = SubResource( 165 )
 
-[node name="Mist 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Mist - Top" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Waterfall"]]
+position = Vector2( -4, -24 )
+scale = Vector2( 8, 8 )
+frames = SubResource( 179 )
+
+[node name="Mist - Bottom Inner" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Inner Mist", "Waterfall"]]
+position = Vector2( 4, 3376 )
+scale = Vector2( 8, 8 )
+frames = SubResource( 171 )
+
+[node name="Mist - Bottom Outer 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( -204, 3328 )
 scale = Vector2( 8, 8 )
 z_index = 1
 frames = SubResource( 70 )
 
-[node name="Mist 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Mist - Bottom Outer 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( 4, 3288 )
 scale = Vector2( 8, 8 )
 z_index = 1
 frames = SubResource( 70 )
 
-[node name="Mist 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper"]
+[node name="Mist - Bottom Outer 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Upper" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( 190, 3328 )
 scale = Vector2( 8, 8 )
 z_index = 1
 frames = SubResource( 70 )
 
-[node name="Waterfall - Lower" type="Area2D" parent="Cliffs"]
+[node name="Waterfall - Lower" type="Area2D" parent="Cliffs" groups=["Parent", "Waterfall"]]
 position = Vector2( 1536, 336 )
 z_index = 32
 collision_layer = 34
 collision_mask = 5
+script = ExtResource( 19 )
 __meta__ = {
 "_edit_group_": true,
 "_edit_lock_": true
 }
 
-[node name="Frozen Ground" type="StaticBody2D" parent="Cliffs/Waterfall - Lower" groups=["Dropdownable", "Ground", "Winter"]]
+[node name="Frozen Ground" type="StaticBody2D" parent="Cliffs/Waterfall - Lower" groups=["Dropdownable", "Ground", "Waterfall", "Winter"]]
 visible = false
 position = Vector2( -4, -220 )
 collision_layer = 2
 collision_mask = 29
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Lower/Frozen Ground" groups=["Dropdownable", "Ground", "Winter"]]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Lower/Frozen Ground" groups=["Dropdownable", "Ground", "Waterfall", "Winter"]]
 shape = SubResource( 203 )
+one_way_collision = true
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Lower"]
-visible = false
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -4, 1763.59 )
 shape = SubResource( 204 )
 
-[node name="Water 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, -16 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 1"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 1" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 20.437
@@ -6001,24 +6003,24 @@ pitch_scale = 0.6
 max_distance = 100.0
 attenuation = 8.28211
 
-[node name="Water 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 368 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 2"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 2" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -16.0
 pitch_scale = 0.6
 attenuation = 8.28211
 
-[node name="Water 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 752 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 3"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 3" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -11.0
@@ -6026,12 +6028,12 @@ pitch_scale = 0.6
 max_distance = 3000.0
 attenuation = 8.28211
 
-[node name="Water 4" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 4" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 1136 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 4"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 4" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -6.0
@@ -6039,12 +6041,12 @@ pitch_scale = 0.6
 max_distance = 4000.0
 attenuation = 8.28211
 
-[node name="Water 5" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 5" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 1520 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 5"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 5" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = -1.0
@@ -6052,12 +6054,12 @@ pitch_scale = 0.6
 max_distance = 5000.0
 attenuation = 8.28211
 
-[node name="Water 6" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 6" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 1904 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 6"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 6" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 4.0
@@ -6065,12 +6067,12 @@ pitch_scale = 0.6
 max_distance = 6000.0
 attenuation = 8.28211
 
-[node name="Water 7" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 7" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 2288 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 7"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 7" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 9.0
@@ -6078,12 +6080,12 @@ pitch_scale = 0.6
 max_distance = 7000.0
 attenuation = 8.28211
 
-[node name="Water 8" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 8" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 2672 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 8"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 8" groups=["Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 14.0
@@ -6091,12 +6093,12 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Water 9" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 9" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 3056 )
 scale = Vector2( 8, 8 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 9"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 9" groups=["Attenuateable", "Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 19.0
@@ -6104,12 +6106,12 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Water 10" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Water 10" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 3470 )
 scale = Vector2( 8, 9.25 )
 frames = SubResource( 64 )
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 10"]
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="Cliffs/Waterfall - Lower/Water 10" groups=["Attenuateable", "Audio", "Waterfall"]]
 scale = Vector2( 0.125, 0.125 )
 stream = ExtResource( 8 )
 volume_db = 24.0
@@ -6117,41 +6119,41 @@ pitch_scale = 0.6
 max_distance = 1000.0
 attenuation = 8.28211
 
-[node name="Mist - Top" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
-position = Vector2( -8, -16 )
-scale = Vector2( 8, 8 )
-frames = SubResource( 179 )
-
-[node name="Pool" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Pool" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 3480 )
 scale = Vector2( 8, 8 )
 z_index = -32
 frames = SubResource( 173 )
 
-[node name="Mist - Bottom" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
-position = Vector2( 0, 3496 )
-scale = Vector2( 8, 8 )
-frames = SubResource( 171 )
-
-[node name="Waves" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Waves" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
 position = Vector2( -8, 3480 )
 scale = Vector2( 8, 8 )
 z_index = -32
 frames = SubResource( 165 )
 
-[node name="Mist 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Mist - Top" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Waterfall"]]
+position = Vector2( -8, -16 )
+scale = Vector2( 8, 8 )
+frames = SubResource( 179 )
+
+[node name="Mist - Bottom Inner" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Inner Mist", "Waterfall"]]
+position = Vector2( 0, 3496 )
+scale = Vector2( 8, 8 )
+frames = SubResource( 171 )
+
+[node name="Mist - Bottom Outer 1" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( -208, 3432 )
 scale = Vector2( 8, 8 )
 z_index = 1
 frames = SubResource( 70 )
 
-[node name="Mist 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Mist - Bottom Outer 2" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( 0, 3392 )
 scale = Vector2( 8, 8 )
 z_index = 1
 frames = SubResource( 70 )
 
-[node name="Mist 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower"]
+[node name="Mist - Bottom Outer 3" type="AnimatedSprite" parent="Cliffs/Waterfall - Lower" groups=["Outer Mist", "Waterfall"]]
 position = Vector2( 186, 3432 )
 scale = Vector2( 8, 8 )
 z_index = 1
@@ -6362,7 +6364,7 @@ collision_mask = 29
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Ground 2/Area2D" groups=["Cliffs", "Ground"]]
 shape = SubResource( 113 )
 
-[node name="Ground 3" type="StaticBody2D" parent="Cliffs" groups=["Cliffs", "Dropdownable", "Ground"]]
+[node name="Ground 3" type="StaticBody2D" parent="Cliffs" groups=["Cliffs", "Dropdownable", "Ground", "Summer", "Waterfall"]]
 visible = false
 position = Vector2( 1532, -3648 )
 collision_layer = 2
@@ -6372,7 +6374,7 @@ __meta__ = {
 "_edit_lock_": true
 }
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Ground 3" groups=["Cliffs", "Dropdownable", "Ground"]]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Ground 3" groups=["Cliffs", "Dropdownable", "Ground", "Summer", "Waterfall"]]
 shape = SubResource( 114 )
 one_way_collision = true
 
@@ -6416,7 +6418,7 @@ __meta__ = {
 }
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Ground 5" groups=["Cliffs", "Dropdownable", "Ground"]]
-position = Vector2( 56, -8 )
+position = Vector2( 56, 4 )
 shape = SubResource( 118 )
 one_way_collision = true
 
@@ -6425,7 +6427,7 @@ collision_layer = 2
 collision_mask = 29
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Cliffs/Ground 5/Area2D" groups=["Cliffs", "Ground"]]
-position = Vector2( 56, -8 )
+position = Vector2( 56, 4 )
 shape = SubResource( 119 )
 
 [node name="Ground 6" type="StaticBody2D" parent="Cliffs" groups=["Cliffs", "Ground"]]
@@ -7106,10 +7108,10 @@ volume_db = -15.0
 [connection signal="timeout" from="Player/Timers/Energy" to="Player" method="_OnEnergyTimerTimeout"]
 [connection signal="timeout" from="Cliffs/Broken Bridge Left - Dynamic/Applied Force Timer" to="Cliffs/Broken Bridge Left - Dynamic" method="_OnAppliedForceTimerTimeout"]
 [connection signal="timeout" from="Cliffs/Broken Bridge Right - Dynamic/Applied Force Timer" to="Cliffs/Broken Bridge Right - Dynamic" method="_OnAppliedForceTimerTimeout"]
-[connection signal="area_entered" from="Cliffs/Waterfall - Upper" to="Cliffs" method="_OnWaterfallEntered"]
-[connection signal="area_exited" from="Cliffs/Waterfall - Upper" to="Cliffs" method="_OnWaterfallExited"]
-[connection signal="area_entered" from="Cliffs/Waterfall - Lower" to="Cliffs" method="_OnWaterfallEntered"]
-[connection signal="area_exited" from="Cliffs/Waterfall - Lower" to="Cliffs" method="_OnWaterfallExited"]
+[connection signal="area_entered" from="Cliffs/Waterfall - Upper" to="Cliffs/Waterfall - Upper" method="_OnWaterfallEntered"]
+[connection signal="area_exited" from="Cliffs/Waterfall - Upper" to="Cliffs/Waterfall - Upper" method="_OnWaterfallExited"]
+[connection signal="area_entered" from="Cliffs/Waterfall - Lower" to="Cliffs/Waterfall - Lower" method="_OnWaterfallEntered"]
+[connection signal="area_exited" from="Cliffs/Waterfall - Lower" to="Cliffs/Waterfall - Lower" method="_OnWaterfallExited"]
 [connection signal="body_exited" from="Cliffs/Edge 1" to="Player" method="_OnCliffEdgeExited"]
 [connection signal="body_exited" from="Cliffs/Edge 2" to="Player" method="_OnCliffEdgeExited"]
 [connection signal="body_exited" from="Cliffs/Edge 3" to="Player" method="_OnCliffEdgeExited"]

--- a/scripts/Dropdown.cs
+++ b/scripts/Dropdown.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Godot;
 
@@ -11,11 +12,14 @@ public class Dropdown : AbstractDropdownable
   private readonly List <RayCast2D> _groundDetectors;
   private readonly List <Task> _tasks = new();
   private readonly List <TileMap> _tileMapRayCastExceptions = new();
+  private readonly string _name;
 
-  public Dropdown (CollisionObject2D droppingNode, List <RayCast2D> groundDetectors)
+  // ReSharper disable once ExplicitCallerInfoArgument
+  public Dropdown (CollisionObject2D droppingNode, List <RayCast2D> groundDetectors, [CallerFilePath] string name = "") : base (name)
   {
     _droppingNode = droppingNode;
     _groundDetectors = groundDetectors;
+    _name = name;
   }
 
   public override async Task Drop()
@@ -40,7 +44,8 @@ public class Dropdown : AbstractDropdownable
 
         if (!groundCollider.IsInGroup ("Dropdownable")) continue;
 
-        var dropdownable = DropdownableFactory.Create (_droppingNode, groundCollider, collisionPoint);
+        // ReSharper disable once ExplicitCallerInfoArgument
+        var dropdownable = DropdownableFactory.Create (_droppingNode, groundCollider, collisionPoint, _name);
         _tasks.Add (dropdownable.Drop());
         if (dropdownable.IsDropping()) _IsDropping = true;
       }

--- a/scripts/DropdownableFactory.cs
+++ b/scripts/DropdownableFactory.cs
@@ -1,14 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using Godot;
 
 public static class DropdownableFactory
 {
-  private static readonly IDropdownable NullDropdownable = new NullDropdownable();
+  private static readonly IDropdownable NullDropdownable = null!;
 
-  public static IDropdownable Create (CollisionObject2D droppingNode, Node2D droppingThroughNode, Vector2 collisionPoint) =>
+  [SuppressMessage ("ReSharper", "ExplicitCallerInfoArgument")]
+  public static IDropdownable Create (CollisionObject2D droppingNode, Node2D droppingThroughNode, Vector2 collisionPoint,
+    [CallerFilePath] string name = "") =>
     droppingThroughNode switch
     {
-      PhysicsBody2D physicsBody => new PhysicsBodyDropdownable (physicsBody, droppingNode),
-      TileMap tileMap => new TileMapDropdownable (tileMap, droppingNode, collisionPoint),
-      _ => NullDropdownable
+      PhysicsBody2D physicsBody => new PhysicsBodyDropdownable (physicsBody, droppingNode, name),
+      TileMap tileMap => new TileMapDropdownable (tileMap, droppingNode, collisionPoint, name),
+      _ => NullDropdownable ?? new NullDropdownable (name)
     };
 }

--- a/scripts/NullDropdownable.cs
+++ b/scripts/NullDropdownable.cs
@@ -1,6 +1,9 @@
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 public class NullDropdownable : AbstractDropdownable
 {
+  // ReSharper disable once ExplicitCallerInfoArgument
+  public NullDropdownable ([CallerFilePath] string name = "") : base (name) { }
   public override Task Drop() => Task.CompletedTask;
 }

--- a/scripts/PhysicsBodyDropdownable.cs
+++ b/scripts/PhysicsBodyDropdownable.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Godot;
 
@@ -6,7 +7,9 @@ public class PhysicsBodyDropdownable : AbstractDropdownable
   private readonly PhysicsBody2D _droppedThroughNode;
   private readonly CollisionObject2D _droppingNode;
 
-  public PhysicsBodyDropdownable (PhysicsBody2D droppedThroughNode, CollisionObject2D droppingNode)
+  // ReSharper disable once ExplicitCallerInfoArgument
+  public PhysicsBodyDropdownable (PhysicsBody2D droppedThroughNode, CollisionObject2D droppingNode, [CallerFilePath] string name = "")
+    : base (name)
   {
     _droppedThroughNode = droppedThroughNode;
     _droppingNode = droppingNode;

--- a/scripts/TileMapDropdownable.cs
+++ b/scripts/TileMapDropdownable.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Godot;
 
@@ -20,7 +21,9 @@ public class TileMapDropdownable : AbstractDropdownable
 
   // @formatter:on
 
-  public TileMapDropdownable (TileMap droppingThroughTileMap, CollisionObject2D droppingNode, Vector2 collisionPoint)
+  // ReSharper disable once ExplicitCallerInfoArgument
+  public TileMapDropdownable (TileMap droppingThroughTileMap, CollisionObject2D droppingNode, Vector2 collisionPoint,
+    [CallerFilePath] string name = "") : base (name)
   {
     _droppingThroughTileMap = droppingThroughTileMap;
     _droppingNode = droppingNode;

--- a/scripts/Tools.cs
+++ b/scripts/Tools.cs
@@ -212,6 +212,39 @@ public static class Tools
     playOn.Play (animationName);
   }
 
+  public static void SetGroupVisible (string groupName, bool isVisible, SceneTree sceneTree)
+  {
+    foreach (Node node in sceneTree.GetNodesInGroup (groupName))
+    {
+      if (node is not CanvasItem item) continue;
+
+      Log.Debug ($"Setting {item.Name} {(item.Visible ? "visible" : "invisible")}.");
+      item.Visible = isVisible;
+    }
+  }
+
+  public static List <T> GetNodesInGroup <T> (SceneTree sceneTree, string group) where T : Node =>
+    GetNodesInGroups <T> (sceneTree, group);
+
+  public static List <T> GetNodesInGroupWithParent <T> (string parent, SceneTree sceneTree, string group) where T : Node =>
+    GetNodesInGroupsWithParent <T> (parent, sceneTree, group);
+
+  public static List <T> GetNodesInGroupsWithParent <T> (string parent, SceneTree sceneTree, params string[] groups) where T : Node =>
+    GetNodesInGroups <T> (sceneTree, groups).Where (x => x.GetParent()?.Name == parent).ToList();
+
+  public static List <T> GetNodesInGroupsWithAnyOfParents <T> (string[] parents, SceneTree sceneTree, params string[] groups)
+    where T : Node =>
+    GetNodesInGroups <T> (sceneTree, groups).Where (x => parents.ToList().Any (y => x.GetParent()?.Name == y)).ToList();
+
+  public static List <T> GetNodesInGroups <T> (SceneTree sceneTree, params string[] groups) where T : Node
+  {
+    if (groups == null || groups.Length == 0) return new List <T>();
+
+    var nodes = sceneTree.GetNodesInGroup (groups[0]).Cast <Node>().Where (x => x is T).Cast <T>();
+
+    return groups.Length == 1 ? nodes.ToList() : nodes.Where (x => groups.Distinct().All (x.IsInGroup)).ToList();
+  }
+
   public static bool IsAnyArrowKeyPressedExcept (Input arrow)
   {
     var up = IsUpArrowPressed();

--- a/scripts/Waterfall.cs
+++ b/scripts/Waterfall.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using Godot;
+using static Tools;
+
+public class Waterfall : Area2D
+{
+  [Export] public Log.Level LogLevel = Log.Level.Info;
+  public bool IsInWaterfall { get; private set; }
+  private Log _log;
+  private Node2D _pool;
+  private Node2D _waves;
+  private List <Node2D> _innerMists;
+  private List <Node2D> _outerMists;
+  private List <AnimatedSprite> _animations;
+  private List <CollisionObject2D> _winterGrounds;
+  private List <CollisionObject2D> _summerGrounds;
+  private List <AudioStreamPlayer2D> _audioPlayers;
+  private List <AudioStreamPlayer2D> _attenuateables;
+  private readonly Dictionary <Cliffs.Season, int> _zIndex = new();
+  private readonly Dictionary <Cliffs.Season, int> _poolZIndex = new();
+  private readonly Dictionary <Cliffs.Season, int> _wavesZIndex = new();
+  private readonly Dictionary <Cliffs.Season, int> _innerMistsZIndex = new();
+  private readonly Dictionary <Cliffs.Season, int> _outerMistsZIndex = new();
+
+  public override void _Ready()
+  {
+    // @formatter:off
+    // ReSharper disable once ExplicitCallerInfoArgument
+    _log = new Log (Name) { CurrentLevel = LogLevel };
+    _animations = GetNodesInGroupWithParent <AnimatedSprite> (Name, GetTree(), "Waterfall");
+    _innerMists = GetNodesInGroupsWithParent <Node2D> (Name, GetTree(), "Waterfall", "Inner Mist");
+    _outerMists = GetNodesInGroupsWithParent <Node2D> (Name, GetTree(), "Waterfall", "Outer Mist");
+    _audioPlayers = GetNodesInGroupsWithParent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio");
+    _winterGrounds = GetNodesInGroupsWithAnyOfParents <CollisionObject2D> (new[] { Name, "Cliffs" }, GetTree(), "Waterfall", "Ground", "Winter");
+    _summerGrounds = GetNodesInGroupsWithAnyOfParents <CollisionObject2D> (new[] { Name, "Cliffs" }, GetTree(), "Waterfall", "Ground", "Summer");
+    _attenuateables = GetNodesInGroupsWithParent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio", "Attenuateable");
+    _pool = GetNode <Node2D> ("Pool");
+    _waves = GetNode <Node2D> ("Waves");
+    _zIndex.Add (Cliffs.Season.Summer, 33);
+    _zIndex.Add (Cliffs.Season.Winter, 1);
+    _poolZIndex.Add (Cliffs.Season.Summer, -32);
+    _poolZIndex.Add (Cliffs.Season.Winter, -1);
+    _wavesZIndex.Add (Cliffs.Season.Summer, -32);
+    _wavesZIndex.Add (Cliffs.Season.Winter, 1);
+    _outerMistsZIndex.Add (Cliffs.Season.Summer, 2);
+    _outerMistsZIndex.Add (Cliffs.Season.Winter, 33);
+    _innerMistsZIndex.Add (Cliffs.Season.Summer, 1);
+    _innerMistsZIndex.Add (Cliffs.Season.Winter, 33);
+    // @formatter:on
+  }
+
+  // ReSharper disable once UnusedMember.Global
+  public void _OnWaterfallEntered (Area2D area)
+  {
+    if (!area.IsInGroup ("Player")) return;
+
+    _log.Info ($"Player entered {Name}.");
+    IsInWaterfall = true;
+  }
+
+  // ReSharper disable once UnusedMember.Global
+  public void _OnWaterfallExited (Area2D area)
+  {
+    if (!area.IsInGroup ("Player")) return;
+
+    _log.Info ($"Player exited {Name}.");
+    IsInWaterfall = false;
+  }
+
+  public void OnSeasonChange (Cliffs.Season season)
+  {
+    Visible = true;
+    ZIndex = _zIndex[season];
+    _pool.ZIndex = _poolZIndex[season];
+    _waves.ZIndex = _wavesZIndex[season];
+    _innerMists.ForEach (x => x.ZIndex = _innerMistsZIndex[season]);
+    _outerMists.ForEach (x => x.ZIndex = _outerMistsZIndex[season]);
+    var isWinter = season == Cliffs.Season.Winter;
+    var isSummer = season == Cliffs.Season.Summer;
+
+    _animations.ForEach (x =>
+    {
+      x.Playing = !isWinter;
+      x.Visible = true;
+    });
+
+    _winterGrounds.ForEach (x =>
+    {
+      x.SetCollisionMaskBit (0, isWinter);
+      x.SetCollisionLayerBit (1, isWinter);
+    });
+
+    _summerGrounds.ForEach (x =>
+    {
+      x.SetCollisionMaskBit (0, isSummer);
+      x.SetCollisionLayerBit (1, isSummer);
+    });
+
+    UpdateAudio (season);
+  }
+
+  public void ChangeSettings (float soundAttenuation, int outerMistsZIndex, float outerMistsAlphaModulation = 1.0f)
+  {
+    _attenuateables.ForEach (x => x.Attenuation = soundAttenuation);
+
+    _outerMists.ForEach (x =>
+    {
+      x.ZIndex = outerMistsZIndex;
+      x.Modulate = new Color (Modulate.r, Modulate.g, Modulate.b, outerMistsAlphaModulation);
+    });
+  }
+
+  private void UpdateAudio (Cliffs.Season season) =>
+    _audioPlayers.ForEach (x =>
+    {
+      LoopAudio (x.Stream);
+      x.Playing = season != Cliffs.Season.Winter;
+    });
+}


### PR DESCRIPTION
Bugfixes:

- Fix waterfall-player collision/detection bugs. Waterfalls now properly
  detect if player is in or out of a waterfall.

- Fix player cliffhanging halfway down lower waterfall. This is related
  to the aforementioned waterfall-player collision/detection bugs.

- Fix player being unable to climb up when cliffhanging at top of lower
  waterfall and changing season from summer to winter and then back to
  summer again. Fix by updating the current season behind-the-scenes
  (programmatically, not graphically) immediately instead of waiting for
  the fade-in/out to finish so the proper ground colliders are enabled
  for the new season before the player falls past them during the season
  transition.

- Fix player not cliffhanging when standing on top of frozen lower
  waterfall ground and changing season from winter to summer. The fix is
  the same as the aforementioned season transition bug.

Refactoring:

- Move waterfall code into its own script and attach it to the waterfall
  nodes.

Miscellaneous:

- Improve dropdown-related logging by specifying the name of the calling
  class, all the way up to the top, i.e., show "Player" as the caller
  name in dropdown-related logging messages, instead of showing no name,
  since "Player" is the top-level caller.
