### PR TITLE
Fix music toggling.

### DIFF
--- a/scripts/Cliffs.cs
+++ b/scripts/Cliffs.cs
@@ -9,6 +9,22 @@ public class Cliffs : Area2D
   [Export] public Season InitialSeason = Season.Summer;
   [Export] public Color InitialClearColor = Color.Color8 (11, 118, 255);
   [Export] public Log.Level LogLevel = Log.Level.Info;
+
+  [Export]
+  public bool MusicPlaying
+  {
+    get => _musicPlayer?.Playing ?? true;
+
+    // ReSharper disable once ValueParameterNotUsed
+    set
+    {
+      if (_musicPlayer == null) return;
+
+      _musicPlayer.Playing = !_musicPlayer.Playing;
+      _seasons?.ToggleMusic();
+    }
+  }
+
   private Seasons _seasons;
   private Player _player;
   private AnimationPlayer _playerPrimaryAnimator;
@@ -26,7 +42,7 @@ public class Cliffs : Area2D
   public override void _Ready()
   {
     // ReSharper disable once ExplicitCallerInfoArgument
-    _seasons = new Seasons (GetTree(), InitialSeason, InitialClearColor, LogLevel);
+    _seasons = new Seasons (GetTree(), InitialSeason, InitialClearColor, true, LogLevel);
     _colliders = GetNodesInGroup <CollisionShape2D> (GetTree(), "Extents");
     _musicPlayer = GetNode <AudioStreamPlayer> ("../Audio Players/Music");
     _iceTileMap = GetNode <TileMap> ("Ice");
@@ -35,6 +51,7 @@ public class Cliffs : Area2D
     _playerAnimation = _playerPrimaryAnimator.CurrentAnimation;
     _playerAnimationAreaColliders = _player.GetNode <Area2D> ("Animations/Area Colliders");
     _playerAnimationCollider = _playerAnimationAreaColliders.GetNode <CollisionShape2D> (_playerAnimation);
+    if (MusicPlaying) _musicPlayer.Play();
   }
 
   public override void _Process (float delta)
@@ -72,5 +89,9 @@ public class Cliffs : Area2D
                                  IsIntersectingAnyTile (_playerAnimationAreaColliders, _playerAnimationCollider, _iceTileMap);
   }
 
-  private void ToggleMusic() => _musicPlayer.Playing = !_musicPlayer.Playing;
+  private void ToggleMusic()
+  {
+    _musicPlayer.Playing = !_musicPlayer.Playing;
+    _seasons.ToggleMusic();
+  }
 }

--- a/scripts/Seasons.cs
+++ b/scripts/Seasons.cs
@@ -31,15 +31,17 @@ public class Seasons
   private Season _oldSeason;
   private bool _fadeIn;
   private bool _skipFade;
+  private bool _isMusicPlaying;
   private readonly Log _log;
 
-  public Seasons (SceneTree sceneTree, Season initialSeason, Color initialClearColor, Log.Level logLevel,
+  public Seasons (SceneTree sceneTree, Season initialSeason, Color initialClearColor, bool isMusicPlayingInitially, Log.Level logLevel,
     [CallerFilePath] string name = "")
   {
     // ReSharper disable once ExplicitCallerInfoArgument
     _log = new Log (name) { CurrentLevel = logLevel };
     _initialClearColor = initialClearColor;
     _clearColor = initialClearColor;
+    _isMusicPlaying = isMusicPlayingInitially;
     _waterfalls = GetNodesInGroups <Waterfall> (sceneTree, "Waterfall", "Parent");
     _ambience.Add (Season.Summer, ResourceLoader.Load <AudioStream> ("res://assets/sounds/ambience_summer.wav"));
     _ambience.Add (Season.Winter, ResourceLoader.Load <AudioStream> ("res://assets/sounds/ambience_winter.wav"));
@@ -58,6 +60,8 @@ public class Seasons
   {
     if (IsReleased (Tools.Input.Season, @event) && !_seasonChangeInProgress) NextSeason();
   }
+
+  public void ToggleMusic() => _isMusicPlaying = !_isMusicPlaying;
 
   public void Update (SceneTree sceneTree, CanvasItem canvas, float delta)
   {
@@ -109,7 +113,7 @@ public class Seasons
 
     if (_seasonChangeInProgress) return;
 
-    _musicPlayer.Play();
+    if (_isMusicPlaying) _musicPlayer.Play();
     _log.Info ($"Current season is now: {CurrentSeason}");
   }
 


### PR DESCRIPTION
- Add setting in Godot editor on Cliffs node for setting music enabled /
  disabled.

- Start with default of music enabled.

- If music is disabled, don't re-enable music when changing seasons.

- Pressing 'M' to enable / disable music works with the Godot editor
  setting. However it is possible to have music "enabled" in the Godot
  editor, and press 'M' in game to disable it, and vice versa.
