### PR TITLE
Set project assembly name in project.godot.

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -161,6 +161,10 @@ attack={
 2d_physics/layer_5="Projectiles"
 2d_physics/layer_6="Environment Background"
 
+[mono]
+
+project/assembly_name="coa"
+
 [rendering]
 
 quality/intended_usage/framebuffer_allocation=1


### PR DESCRIPTION
- This appears to be an automatic change in the Godot
  3.5.1.stable.mono editor.
