### PR TITLE
Fix waterfall sound effects.

### DIFF
--- a/scripts/Tools.cs
+++ b/scripts/Tools.cs
@@ -211,6 +211,18 @@ public static class Tools
     where T : Node =>
     GetNodesInGroups <T> (sceneTree, groups).Where (x => parents.ToList().Any (y => x.GetParent()?.Name == y)).ToList();
 
+  public static List <T> GetNodesInGroupWithGrandparent <T> (string grandparent, SceneTree sceneTree, string group) where T : Node =>
+    GetNodesInGroupsWithGrandparent <T> (grandparent, sceneTree, group);
+
+  public static List <T> GetNodesInGroupsWithGrandparent <T> (string grandparent, SceneTree sceneTree, params string[] groups)
+    where T : Node =>
+    GetNodesInGroups <T> (sceneTree, groups).Where (x => x.GetParent()?.GetParent()?.Name == grandparent).ToList();
+
+  public static List <T> GetNodesInGroupsWithAnyOfGrandparents <T> (string[] grandparents, SceneTree sceneTree, params string[] groups)
+    where T : Node =>
+    GetNodesInGroups <T> (sceneTree, groups).Where (x => grandparents.ToList().Any (y => x.GetParent()?.GetParent()?.Name == y))
+      .ToList();
+
   public static List <T> GetNodesInGroups <T> (SceneTree sceneTree, params string[] groups) where T : Node
   {
     if (groups == null || groups.Length == 0) return new List <T>();

--- a/scripts/Waterfall.cs
+++ b/scripts/Waterfall.cs
@@ -33,10 +33,10 @@ public class Waterfall : Area2D
     _animations = GetNodesInGroupWithParent <AnimatedSprite> (Name, GetTree(), "Waterfall");
     _innerMists = GetNodesInGroupsWithParent <Node2D> (Name, GetTree(), "Waterfall", "Inner Mist");
     _outerMists = GetNodesInGroupsWithParent <Node2D> (Name, GetTree(), "Waterfall", "Outer Mist");
-    _audioPlayers = GetNodesInGroupsWithParent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio");
+    _audioPlayers = GetNodesInGroupsWithGrandparent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio");
     _winterGrounds = GetNodesInGroupsWithAnyOfParents <CollisionObject2D> (new[] { Name, "Cliffs" }, GetTree(), "Waterfall", "Ground", "Winter");
     _summerGrounds = GetNodesInGroupsWithAnyOfParents <CollisionObject2D> (new[] { Name, "Cliffs" }, GetTree(), "Waterfall", "Ground", "Summer");
-    _attenuateables = GetNodesInGroupsWithParent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio", "Attenuateable");
+    _attenuateables = GetNodesInGroupsWithGrandparent <AudioStreamPlayer2D> (Name, GetTree(), "Waterfall", "Audio", "Attenuateable");
     _pool = GetNode <Node2D> ("Pool");
     _waves = GetNode <Node2D> ("Waves");
     _zIndex.Add (Season.Summer, 33);


### PR DESCRIPTION
- Audio nodes are grandchildren of the base waterfall nodes, not
  children.

- Add utility methods to get nodes in groups having a specific
  grandparent.
